### PR TITLE
Add Dockerfiles for services and compose config

### DIFF
--- a/cmd/astrology_report/Dockerfile
+++ b/cmd/astrology_report/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.21-alpine AS build
+WORKDIR /app
+COPY . .
+RUN go build -o astrology_report ./cmd/astrology_report
+
+FROM alpine
+COPY --from=build /app/astrology_report /service
+ENTRYPOINT ["/service"]

--- a/cmd/auth/Dockerfile
+++ b/cmd/auth/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.21-alpine AS build
+WORKDIR /app
+COPY . .
+RUN go build -o auth ./cmd/auth
+
+FROM alpine
+COPY --from=build /app/auth /service
+ENTRYPOINT ["/service"]

--- a/cmd/chat/Dockerfile
+++ b/cmd/chat/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.21-alpine AS build
+WORKDIR /app
+COPY . .
+RUN go build -o chat ./cmd/chat
+
+FROM alpine
+COPY --from=build /app/chat /service
+ENTRYPOINT ["/service"]

--- a/cmd/match/Dockerfile
+++ b/cmd/match/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.21-alpine AS build
+WORKDIR /app
+COPY . .
+RUN go build -o match ./cmd/match
+
+FROM alpine
+COPY --from=build /app/match /service
+ENTRYPOINT ["/service"]

--- a/cmd/user/Dockerfile
+++ b/cmd/user/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.21-alpine AS build
+WORKDIR /app
+COPY . .
+RUN go build -o user ./cmd/user
+
+FROM alpine
+COPY --from=build /app/user /service
+ENTRYPOINT ["/service"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_PASSWORD: example
+    ports:
+      - "5432:5432"
+  mongodb:
+    image: mongo:7
+    ports:
+      - "27017:27017"
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+
+  auth:
+    build: ./cmd/auth
+    ports:
+      - "8081:8080"
+    depends_on:
+      - postgres
+  chat:
+    build: ./cmd/chat
+    ports:
+      - "8082:8080"
+    depends_on:
+      - redis
+  match:
+    build: ./cmd/match
+    ports:
+      - "8083:8080"
+    depends_on:
+      - postgres
+  user:
+    build: ./cmd/user
+    ports:
+      - "8084:8080"
+    depends_on:
+      - postgres
+  astrology_report:
+    build: ./cmd/astrology_report
+    ports:
+      - "8085:8080"
+    depends_on:
+      - mongodb
+      - redis


### PR DESCRIPTION
## Summary
- provide simple Dockerfiles for all services under `cmd`
- add a docker-compose setup with PostgreSQL, MongoDB, Redis and all services

## Testing
- `gofmt -w internal/handlers/ping.go cmd/*/main.go`


------
https://chatgpt.com/codex/tasks/task_b_686e93657744832a98fcc3dfab8ab677