### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: Go CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Run go fmt
+        run: gofmt -w $(go list -f '{{.Dir}}' ./... | tr '\n' ' ')
+
+      - name: Run go test
+        run: go test ./...
+
+      - name: Build services
+        run: |
+          for dir in $(go list -f '{{.Dir}}' ./...); do
+            (cd "$dir" && if [ -f main.go ]; then go build ./...; fi)
+          done
+
+      - name: Docker build
+        if: false
+        run: echo "Add Docker build commands here"
+


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to vet, fmt, test and build Go services

## Testing
- `go vet ./...` *(fails: directory prefix . does not contain main module)*
- `go fmt ./...` *(fails: directory prefix . does not contain main module)*
- `go test ./...` *(fails: directory prefix . does not contain main module)*


------
https://chatgpt.com/codex/tasks/task_b_686e9366c6c0832abb492a6e817cbdcd