### PR TITLE
Add global logrus logger and custom Gin engine

### DIFF
--- a/cmd/astrology_report/main.go
+++ b/cmd/astrology_report/main.go
@@ -3,16 +3,17 @@ package main
 import (
 	"context"
 
-	"github.com/gin-gonic/gin"
 	"github.com/redis/go-redis/v9"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"matchmaker/internal/handlers"
+	"matchmaker/internal/logging"
 )
 
 func main() {
-	r := gin.Default()
+	logging.Init()
+	r := logging.NewGinEngine()
 	r.GET("/ping", handlers.Ping)
 
 	// Placeholder MongoDB and Redis initialization to reference libraries.

--- a/cmd/auth/main.go
+++ b/cmd/auth/main.go
@@ -1,14 +1,15 @@
 package main
 
 import (
-	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v4"
 
 	"matchmaker/internal/handlers"
+	"matchmaker/internal/logging"
 )
 
 func main() {
-	r := gin.Default()
+	logging.Init()
+	r := logging.NewGinEngine()
 	r.GET("/ping", handlers.Ping)
 
 	// Example usage of jwt-go to ensure dependency is referenced.

--- a/cmd/chat/main.go
+++ b/cmd/chat/main.go
@@ -1,14 +1,15 @@
 package main
 
 import (
-	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 
 	"matchmaker/internal/handlers"
+	"matchmaker/internal/logging"
 )
 
 func main() {
-	r := gin.Default()
+	logging.Init()
+	r := logging.NewGinEngine()
 	r.GET("/ping", handlers.Ping)
 
 	// Placeholder websocket usage to reference the library.

--- a/cmd/match/main.go
+++ b/cmd/match/main.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"github.com/gin-gonic/gin"
-
 	"matchmaker/internal/handlers"
+	"matchmaker/internal/logging"
 )
 
 func main() {
-	r := gin.Default()
+	logging.Init()
+	r := logging.NewGinEngine()
 	r.GET("/ping", handlers.Ping)
 
 	r.Run()

--- a/cmd/user/main.go
+++ b/cmd/user/main.go
@@ -1,16 +1,17 @@
 package main
 
 import (
-	"github.com/gin-gonic/gin"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"matchmaker/internal/handlers"
+	"matchmaker/internal/logging"
 	"matchmaker/internal/models"
 )
 
 func main() {
-	r := gin.Default()
+	logging.Init()
+	r := logging.NewGinEngine()
 	r.GET("/ping", handlers.Ping)
 
 	// Placeholder GORM initialization to reference the library.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/gorilla/websocket v1.5.3
 	github.com/redis/go-redis/v9 v9.11.0
+	github.com/sirupsen/logrus v1.9.3
 	go.mongodb.org/mongo-driver v1.17.4
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/redis/go-redis/v9 v9.11.0 h1:E3S08Gl/nJNn5vkxd2i78wZxWAPNZgUNTp8WIJUA
 github.com/redis/go-redis/v9 v9.11.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -134,6 +136,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,46 @@
+package logging
+
+import (
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+var Log *logrus.Logger
+
+// Init configures the global logger.
+func Init() {
+	Log = logrus.New()
+	Log.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
+}
+
+// NewGinEngine returns a Gin engine that logs requests and panics using Log.
+func NewGinEngine() *gin.Engine {
+	if Log == nil {
+		Init()
+	}
+	engine := gin.New()
+	engine.Use(gin.RecoveryWithWriter(Log.Writer()))
+	engine.Use(requestLogger())
+	return engine
+}
+
+func requestLogger() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		c.Next()
+		entry := Log.WithFields(logrus.Fields{
+			"status":   c.Writer.Status(),
+			"method":   c.Request.Method,
+			"path":     c.Request.URL.Path,
+			"clientIP": c.ClientIP(),
+			"latency":  time.Since(start),
+		})
+		if len(c.Errors) > 0 {
+			entry.Error(c.Errors.String())
+		} else {
+			entry.Info("request handled")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `internal/logging` package with global logrus logger
- use `logging.NewGinEngine()` in all services
- call `logging.Init()` before running Gin
- include logrus in module dependencies

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_b_686f4aa593c8832a953b87f4293228bf