### PR TITLE
Implement OAuth login in auth service

### DIFF
--- a/cmd/auth/main.go
+++ b/cmd/auth/main.go
@@ -1,19 +1,184 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v4"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 
 	"matchmaker/internal/handlers"
 	"matchmaker/internal/logging"
 )
 
+var (
+	oauthConfig    *oauth2.Config
+	jwtPrivateKey  *rsa.PrivateKey
+	userServiceURL string
+)
+
 func main() {
 	logging.Init()
+
+	oauthConfig = &oauth2.Config{
+		ClientID:     os.Getenv("GOOGLE_OAUTH_CLIENT_ID"),
+		ClientSecret: os.Getenv("GOOGLE_OAUTH_CLIENT_SECRET"),
+		RedirectURL:  getenv("GOOGLE_OAUTH_REDIRECT_URL", "http://localhost:8081/api/v1/auth/google/callback"),
+		Scopes: []string{
+			"https://www.googleapis.com/auth/userinfo.email",
+			"https://www.googleapis.com/auth/userinfo.profile",
+		},
+		Endpoint: google.Endpoint,
+	}
+
+	keyData := os.Getenv("JWT_PRIVATE_KEY")
+	if keyData != "" {
+		block, _ := pem.Decode([]byte(keyData))
+		if block != nil {
+			if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+				jwtPrivateKey = key
+			} else {
+				logging.Log.WithError(err).Error("failed to parse RSA private key")
+			}
+		}
+	}
+
+	userServiceURL = getenv("USER_SERVICE_URL", "http://localhost:8084")
+
 	r := logging.NewGinEngine()
 	r.GET("/ping", handlers.Ping)
+	r.GET("/api/v1/auth/google/login", googleLoginHandler)
+	r.GET("/api/v1/auth/google/callback", googleCallbackHandler)
 
 	// Example usage of jwt-go to ensure dependency is referenced.
 	_ = jwt.New(jwt.SigningMethodHS256)
 
 	r.Run()
+}
+
+func getenv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func googleLoginHandler(c *gin.Context) {
+	if oauthConfig == nil {
+		logging.Log.Error("oauth config not initialized")
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+	url := oauthConfig.AuthCodeURL("state", oauth2.AccessTypeOffline)
+	logging.Log.WithField("url", url).Info("redirecting to google oauth")
+	c.Redirect(http.StatusFound, url)
+}
+
+func googleCallbackHandler(c *gin.Context) {
+	code := c.Query("code")
+	if code == "" {
+		logging.Log.Warn("missing code in callback")
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing code"})
+		return
+	}
+
+	tok, err := oauthConfig.Exchange(context.Background(), code)
+	if err != nil {
+		logging.Log.WithError(err).Error("token exchange failed")
+		c.JSON(http.StatusBadRequest, gin.H{"error": "token exchange failed"})
+		return
+	}
+
+	client := oauthConfig.Client(context.Background(), tok)
+	resp, err := client.Get("https://www.googleapis.com/oauth2/v2/userinfo")
+	if err != nil {
+		logging.Log.WithError(err).Error("failed to fetch user info")
+		c.JSON(http.StatusBadGateway, gin.H{"error": "failed to fetch user info"})
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		logging.Log.WithField("status", resp.StatusCode).WithField("body", string(body)).Error("google userinfo returned non-200")
+		c.JSON(http.StatusBadGateway, gin.H{"error": "google userinfo failed"})
+		return
+	}
+
+	var gUser struct {
+		Email string `json:"email"`
+		Name  string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&gUser); err != nil {
+		logging.Log.WithError(err).Error("failed to decode user info")
+		c.JSON(http.StatusBadGateway, gin.H{"error": "invalid user info"})
+		return
+	}
+
+	// Call User Service
+	body, err := json.Marshal(map[string]string{
+		"email": gUser.Email,
+		"name":  gUser.Name,
+	})
+	if err != nil {
+		logging.Log.WithError(err).Error("failed to marshal user request")
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+
+	usResp, err := http.Post(userServiceURL+"/internal/v1/users", "application/json", bytes.NewReader(body))
+	if err != nil {
+		logging.Log.WithError(err).Error("user service request failed")
+		c.JSON(http.StatusBadGateway, gin.H{"error": "user service unavailable"})
+		return
+	}
+	defer usResp.Body.Close()
+	if usResp.StatusCode != http.StatusOK && usResp.StatusCode != http.StatusCreated {
+		b, _ := io.ReadAll(usResp.Body)
+		logging.Log.WithFields(map[string]interface{}{"status": usResp.StatusCode, "body": string(b)}).Error("user service returned error")
+		c.JSON(http.StatusBadGateway, gin.H{"error": "user service error"})
+		return
+	}
+	var userResp struct {
+		ID uint `json:"id"`
+	}
+	if err := json.NewDecoder(usResp.Body).Decode(&userResp); err != nil {
+		logging.Log.WithError(err).Error("failed to decode user service response")
+		c.JSON(http.StatusBadGateway, gin.H{"error": "invalid user service response"})
+		return
+	}
+
+	if jwtPrivateKey == nil {
+		logging.Log.Error("jwt private key not configured")
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+
+	claims := jwt.MapClaims{
+		"user_id": userResp.ID,
+		"email":   gUser.Email,
+		"roles":   []string{"user"},
+		"exp":     time.Now().Add(24 * time.Hour).Unix(),
+		"iat":     time.Now().Unix(),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	signed, err := token.SignedString(jwtPrivateKey)
+	if err != nil {
+		logging.Log.WithError(err).Error("failed to sign jwt")
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+
+	logging.Log.WithField("user_id", userResp.ID).Info("authentication successful")
+	c.JSON(http.StatusOK, gin.H{"token": signed})
 }

--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,13 @@ require (
 	github.com/redis/go-redis/v9 v9.11.0
 	github.com/sirupsen/logrus v1.9.3
 	go.mongodb.org/mongo-driver v1.17.4
+	golang.org/x/oauth2 v0.30.0
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.30.0
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	github.com/bytedance/sonic v1.11.6 // indirect
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
+cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
@@ -128,6 +130,8 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.25.0 h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac=
 golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
+golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
+golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=


### PR DESCRIPTION
## Summary
- implement OAuth login and callback endpoints for Google
- sign JWTs for authenticated users
- call user service internally to create/retrieve users
- configure new dependencies in go.mod

## Testing
- `go mod tidy`
- `go build ./cmd/auth`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_686f4c6cd4e8832abb3b0810ed97a316