### PR TITLE
Implement DB connection and user service handlers

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1,0 +1,27 @@
+package database
+
+import (
+	"os"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"matchmaker/internal/logging"
+)
+
+var DB *gorm.DB
+
+// Init opens a GORM connection using POSTGRES_URL. On success it sets DB.
+func Init() (*gorm.DB, error) {
+	dsn := os.Getenv("POSTGRES_URL")
+	if dsn == "" {
+		logging.Log.Warn("POSTGRES_URL not set")
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		logging.Log.WithError(err).Error("failed to connect to postgres")
+		return nil, err
+	}
+	DB = db
+	return db, nil
+}

--- a/internal/handlers/middleware.go
+++ b/internal/handlers/middleware.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v4"
+
+	"matchmaker/internal/logging"
+)
+
+// RequireUserID parses the JWT in the Authorization header and stores the user_id claim in the context.
+func RequireUserID() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		auth := c.GetHeader("Authorization")
+		if !strings.HasPrefix(auth, "Bearer ") {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing bearer token"})
+			return
+		}
+		tokenStr := strings.TrimPrefix(auth, "Bearer ")
+		claims := jwt.MapClaims{}
+		if _, _, err := new(jwt.Parser).ParseUnverified(tokenStr, claims); err != nil {
+			logging.Log.WithError(err).Warn("failed to parse jwt")
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
+			return
+		}
+		id, ok := claims["user_id"].(float64)
+		if !ok {
+			logging.Log.Warn("user_id claim missing")
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
+			return
+		}
+		c.Set("user_id", uint(id))
+		c.Next()
+	}
+}

--- a/internal/handlers/user.go
+++ b/internal/handlers/user.go
@@ -1,0 +1,100 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"matchmaker/internal/database"
+	"matchmaker/internal/logging"
+	"matchmaker/internal/models"
+)
+
+// CreateUser creates a user if it does not exist and returns the ID.
+func CreateUser(c *gin.Context) {
+	var req struct {
+		Email string `json:"email"`
+		Name  string `json:"name"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil || req.Email == "" {
+		logging.Log.WithError(err).Warn("invalid create user payload")
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+
+	var user models.User
+	err := database.DB.Where("email = ?", req.Email).First(&user).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			user = models.User{Email: req.Email}
+			if err := database.DB.Create(&user).Error; err != nil {
+				logging.Log.WithError(err).Error("failed to create user")
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "create failed"})
+				return
+			}
+			c.JSON(http.StatusCreated, gin.H{"id": user.ID})
+			return
+		}
+		logging.Log.WithError(err).Error("failed to query user")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "database error"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"id": user.ID})
+}
+
+// GetMe returns the authenticated user's profile.
+func GetMe(c *gin.Context) {
+	uid := c.GetUint("user_id")
+	var user models.User
+	if err := database.DB.Preload("BirthDetail").First(&user, uid).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+			return
+		}
+		logging.Log.WithError(err).Error("failed to fetch user")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "database error"})
+		return
+	}
+	c.JSON(http.StatusOK, user)
+}
+
+// UpdateMe updates profile fields for the authenticated user.
+func UpdateMe(c *gin.Context) {
+	uid := c.GetUint("user_id")
+	var req struct {
+		Gender   string `json:"gender"`
+		Location string `json:"location"`
+		PhotoURL string `json:"photoURL"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		logging.Log.WithError(err).Warn("invalid update payload")
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+	var user models.User
+	if err := database.DB.First(&user, uid).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+			return
+		}
+		logging.Log.WithError(err).Error("failed to fetch user")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "database error"})
+		return
+	}
+	if req.Gender != "" {
+		user.Gender = req.Gender
+	}
+	if req.Location != "" {
+		user.Location = req.Location
+	}
+	if req.PhotoURL != "" {
+		user.PhotoURL = req.PhotoURL
+	}
+	if err := database.DB.Save(&user).Error; err != nil {
+		logging.Log.WithError(err).Error("failed to update user")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "update failed"})
+		return
+	}
+	c.JSON(http.StatusOK, user)
+}


### PR DESCRIPTION
## Summary
- add `internal/database` for GORM connection via `POSTGRES_URL`
- create JWT middleware and user handlers
- initialize DB connection and auto-migrate in user service
- expose create user, get profile and update profile endpoints

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./cmd/user`


------
https://chatgpt.com/codex/tasks/task_b_686f4f420160832aab1c2d6f42a7de1d