### PR TITLE
Add astrology report caching endpoint

### DIFF
--- a/cmd/astrology_report/main.go
+++ b/cmd/astrology_report/main.go
@@ -1,24 +1,22 @@
 package main
 
 import (
-	"context"
-
-	"github.com/redis/go-redis/v9"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
-
+	"matchmaker/internal/database"
 	"matchmaker/internal/handlers"
 	"matchmaker/internal/logging"
 )
 
 func main() {
 	logging.Init()
+	if _, err := database.InitMongo(); err != nil {
+		logging.Log.Fatal("mongodb initialization failed")
+	}
+	if _, err := database.InitRedis(); err != nil {
+		logging.Log.Fatal("redis initialization failed")
+	}
+
 	r := logging.NewGinEngine()
 	r.GET("/ping", handlers.Ping)
-
-	// Placeholder MongoDB and Redis initialization to reference libraries.
-	_, _ = mongo.Connect(context.Background(), options.Client().ApplyURI("mongodb://localhost:27017"))
-	_ = redis.NewClient(&redis.Options{Addr: "localhost:6379"})
-
+	r.POST("/internal/v1/reports", handlers.CreateReport)
 	r.Run()
 }

--- a/internal/database/mongo.go
+++ b/internal/database/mongo.go
@@ -1,0 +1,28 @@
+package database
+
+import (
+	"context"
+	"os"
+
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"matchmaker/internal/logging"
+)
+
+var Mongo *mongo.Database
+
+// InitMongo connects to MongoDB using MONGO_URL.
+func InitMongo() (*mongo.Database, error) {
+	uri := os.Getenv("MONGO_URL")
+	if uri == "" {
+		logging.Log.Warn("MONGO_URL not set")
+	}
+	client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(uri))
+	if err != nil {
+		logging.Log.WithError(err).Error("failed to connect to mongodb")
+		return nil, err
+	}
+	Mongo = client.Database("astrology")
+	return Mongo, nil
+}

--- a/internal/database/redis.go
+++ b/internal/database/redis.go
@@ -1,0 +1,32 @@
+package database
+
+import (
+	"context"
+	"os"
+
+	"github.com/redis/go-redis/v9"
+
+	"matchmaker/internal/logging"
+)
+
+var Redis *redis.Client
+
+// InitRedis connects to Redis using REDIS_URL.
+func InitRedis() (*redis.Client, error) {
+	url := os.Getenv("REDIS_URL")
+	if url == "" {
+		logging.Log.Warn("REDIS_URL not set")
+	}
+	opts, err := redis.ParseURL(url)
+	if err != nil {
+		logging.Log.WithError(err).Error("invalid redis url")
+		return nil, err
+	}
+	client := redis.NewClient(opts)
+	if err := client.Ping(context.Background()).Err(); err != nil {
+		logging.Log.WithError(err).Error("failed to connect to redis")
+		return nil, err
+	}
+	Redis = client
+	return client, nil
+}

--- a/internal/handlers/report.go
+++ b/internal/handlers/report.go
@@ -1,0 +1,124 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/redis/go-redis/v9"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"matchmaker/internal/database"
+	"matchmaker/internal/logging"
+)
+
+type BirthDetails struct {
+	DOB string  `json:"dob"`
+	TOB string  `json:"tob"`
+	Lat float64 `json:"lat"`
+	Lon float64 `json:"lon"`
+}
+
+// CreateReport handles POST /internal/v1/reports to fetch astrology reports.
+func CreateReport(c *gin.Context) {
+	var bd BirthDetails
+	if err := c.ShouldBindJSON(&bd); err != nil {
+		logging.Log.WithError(err).Warn("invalid report payload")
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+
+	key := reportKey(bd)
+	ctx := context.Background()
+
+	// L1 Cache (Redis)
+	if val, err := database.Redis.Get(ctx, key).Result(); err == nil {
+		c.Data(http.StatusOK, "application/json", []byte(val))
+		return
+	} else if err != redis.Nil {
+		logging.Log.WithError(err).WithField("key", key).Error("redis get failed")
+	}
+
+	// L2 Cache (MongoDB)
+	var doc struct {
+		Report json.RawMessage `bson:"report"`
+	}
+	if err := database.Mongo.Collection("reports").FindOne(ctx, bson.M{"_id": key}).Decode(&doc); err == nil {
+		c.Data(http.StatusOK, "application/json", doc.Report)
+		go writeCaches(key, doc.Report)
+		return
+	} else if err != mongo.ErrNoDocuments {
+		logging.Log.WithError(err).WithField("key", key).Error("mongo find failed")
+	}
+
+	// Cache miss - fetch from external engine
+	data, err := fetchFromEngine(ctx, bd)
+	if err != nil {
+		logging.Log.WithError(err).Error("engine request failed")
+		c.JSON(http.StatusBadGateway, gin.H{"error": "engine error"})
+		return
+	}
+
+	c.Data(http.StatusOK, "application/json", data)
+	go writeCaches(key, data)
+}
+
+func reportKey(b BirthDetails) string {
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%s:%s:%.8f:%.8f", b.DOB, b.TOB, b.Lat, b.Lon)))
+	return hex.EncodeToString(sum[:])
+}
+
+func fetchFromEngine(ctx context.Context, b BirthDetails) ([]byte, error) {
+	url := os.Getenv("ASTROLOGY_ENGINE_URL")
+	apiKey := os.Getenv("ASTROLOGY_ENGINE_API_KEY")
+	if url == "" {
+		return nil, fmt.Errorf("ASTROLOGY_ENGINE_URL not set")
+	}
+	body, err := json.Marshal(b)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		bts, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("engine status %d: %s", resp.StatusCode, string(bts))
+	}
+	return io.ReadAll(resp.Body)
+}
+
+func writeCaches(key string, data []byte) {
+	ctx := context.Background()
+	if err := database.Redis.Set(ctx, key, data, time.Hour).Err(); err != nil {
+		logging.Log.WithError(err).WithField("key", key).Error("redis set failed")
+	}
+	_, err := database.Mongo.Collection("reports").UpdateOne(ctx,
+		bson.M{"_id": key},
+		bson.M{"$set": bson.M{"report": data, "createdAt": time.Now()}},
+		options.Update().SetUpsert(true),
+	)
+	if err != nil {
+		logging.Log.WithError(err).WithField("key", key).Error("mongo upsert failed")
+	}
+}


### PR DESCRIPTION
## Summary
- wire Mongo and Redis connections from environment variables
- implement POST `/internal/v1/reports` with multi-level cache
- add helper packages for MongoDB and Redis
- initialize caches in astrology report service

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_b_686f72ff02e4832a9a07da0322b5e48b