### PR TITLE
Add API Gateway service

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Services use the following environment variables. Create a `.env` file or export
 | `GOOGLE_OAUTH_REDIRECT_URL` | OAuth callback URL used by the Auth Service |
 | `USER_SERVICE_URL` | Endpoint of the User Service |
 | `REPORT_SERVICE_URL` | Endpoint of the Astrology Report Service |
+| `AUTH_SERVICE_URL` | Endpoint of the Auth Service |
+| `MATCH_SERVICE_URL` | Endpoint of the Match Analysis Service |
+| `CHAT_SERVICE_URL` | Endpoint of the AI Chat Service |
 | `LLM_API_URL` | Endpoint of the LLM provider for the Chat Service |
 
 ## Third-Party Dependencies

--- a/cmd/gateway/Dockerfile
+++ b/cmd/gateway/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.21-alpine AS build
+WORKDIR /app
+COPY . .
+RUN go build -o gateway ./cmd/gateway
+
+FROM alpine
+COPY --from=build /app/gateway /service
+ENTRYPOINT ["/service"]

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"matchmaker/internal/config"
+	"matchmaker/internal/handlers"
+	"matchmaker/internal/logging"
+)
+
+func main() {
+	logging.Init()
+	cfg, err := config.LoadGateway()
+	if err != nil {
+		logging.Log.Fatal(err)
+	}
+	gw, err := handlers.NewGateway(cfg.AuthServiceURL, cfg.UserServiceURL, cfg.MatchServiceURL, cfg.ChatServiceURL, cfg.JWTPrivateKey, 8)
+	if err != nil {
+		logging.Log.Fatal(err)
+	}
+
+	r := logging.NewGinEngine()
+	r.GET("/ping", handlers.Ping)
+	r.Any("/api/v1/auth/*proxyPath", gw.AuthHandler())
+
+	api := r.Group("/api/v1")
+	api.Use(gw.JWTMiddleware())
+	api.Any("/users/*path", gw.UserHandler())
+	api.Any("/analysis", gw.MatchHandler())
+	api.Any("/chat", gw.ChatHandler())
+
+	r.Run()
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,3 +46,14 @@ services:
     depends_on:
       - mongodb
       - redis
+
+  gateway:
+    build: ./cmd/gateway
+    ports:
+      - "8080:8080"
+    depends_on:
+      - auth
+      - chat
+      - match
+      - user
+      - astrology_report

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,3 +135,27 @@ func LoadChat() (*Chat, error) {
 	}
 	return cfg, nil
 }
+
+// Gateway holds configuration for the API gateway.
+type Gateway struct {
+	AuthServiceURL  string
+	UserServiceURL  string
+	MatchServiceURL string
+	ChatServiceURL  string
+	JWTPrivateKey   string
+}
+
+// LoadGateway loads configuration for the gateway service.
+func LoadGateway() (*Gateway, error) {
+	key, err := require("JWT_PRIVATE_KEY")
+	if err != nil {
+		return nil, err
+	}
+	return &Gateway{
+		AuthServiceURL:  getenv("AUTH_SERVICE_URL", "http://localhost:8081"),
+		UserServiceURL:  getenv("USER_SERVICE_URL", "http://localhost:8084"),
+		MatchServiceURL: getenv("MATCH_SERVICE_URL", "http://localhost:8083"),
+		ChatServiceURL:  getenv("CHAT_SERVICE_URL", "http://localhost:8082"),
+		JWTPrivateKey:   key,
+	}, nil
+}

--- a/internal/handlers/gateway.go
+++ b/internal/handlers/gateway.go
@@ -1,0 +1,122 @@
+package handlers
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	stdproxy "net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v4"
+
+	"matchmaker/internal/httputil"
+	"matchmaker/internal/logging"
+)
+
+// workerPool limits concurrent proxy requests.
+type workerPool struct {
+	jobs chan func()
+}
+
+func newWorkerPool(n int) *workerPool {
+	p := &workerPool{jobs: make(chan func())}
+	for i := 0; i < n; i++ {
+		go func() {
+			for fn := range p.jobs {
+				fn()
+			}
+		}()
+	}
+	return p
+}
+
+func (p *workerPool) Do(fn func()) {
+	done := make(chan struct{})
+	p.jobs <- func() { fn(); close(done) }
+	<-done
+}
+
+// Gateway proxies requests to internal services.
+type Gateway struct {
+	auth  *stdproxy.ReverseProxy
+	user  *stdproxy.ReverseProxy
+	match *stdproxy.ReverseProxy
+	chat  *stdproxy.ReverseProxy
+	key   *rsa.PublicKey
+	pool  *workerPool
+}
+
+// NewGateway constructs a Gateway using service URLs and RSA key.
+func NewGateway(authURL, userURL, matchURL, chatURL, pemKey string, workers int) (*Gateway, error) {
+	parse := func(u string) (*stdproxy.ReverseProxy, error) {
+		url, err := url.Parse(u)
+		if err != nil {
+			return nil, err
+		}
+		p := stdproxy.NewSingleHostReverseProxy(url)
+		return p, nil
+	}
+	auth, err := parse(authURL)
+	if err != nil {
+		return nil, err
+	}
+	user, err := parse(userURL)
+	if err != nil {
+		return nil, err
+	}
+	match, err := parse(matchURL)
+	if err != nil {
+		return nil, err
+	}
+	chat, err := parse(chatURL)
+	if err != nil {
+		return nil, err
+	}
+
+	block, _ := pem.Decode([]byte(pemKey))
+	if block == nil {
+		return nil, fmt.Errorf("invalid RSA key")
+	}
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Gateway{auth, user, match, chat, &key.PublicKey, newWorkerPool(workers)}, nil
+}
+
+func (g *Gateway) proxy(p *stdproxy.ReverseProxy) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		g.pool.Do(func() { p.ServeHTTP(c.Writer, c.Request) })
+	}
+}
+
+// JWTMiddleware verifies tokens using the configured RSA key.
+func (g *Gateway) JWTMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		auth := c.GetHeader("Authorization")
+		if !strings.HasPrefix(auth, "Bearer ") {
+			httputil.AbortJSONError(c, http.StatusUnauthorized, "missing bearer token")
+			return
+		}
+		tokenStr := strings.TrimPrefix(auth, "Bearer ")
+		token, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
+			return g.key, nil
+		})
+		if err != nil || !token.Valid {
+			logging.Log.WithError(err).Warn("jwt verification failed")
+			httputil.AbortJSONError(c, http.StatusUnauthorized, "invalid token")
+			return
+		}
+		c.Next()
+	}
+}
+
+func (g *Gateway) AuthHandler() gin.HandlerFunc  { return g.proxy(g.auth) }
+func (g *Gateway) UserHandler() gin.HandlerFunc  { return g.proxy(g.user) }
+func (g *Gateway) MatchHandler() gin.HandlerFunc { return g.proxy(g.match) }
+func (g *Gateway) ChatHandler() gin.HandlerFunc  { return g.proxy(g.chat) }

--- a/internal/handlers/gateway_test.go
+++ b/internal/handlers/gateway_test.go
@@ -1,0 +1,75 @@
+package handlers
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v4"
+)
+
+func genKey(t *testing.T) *rsa.PrivateKey {
+	key, err := rsa.GenerateKey(rand.Reader, 512)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+func TestGatewayUserProxy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	key := genKey(t)
+	pemKey := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+
+	hit := false
+	userSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		if r.Header.Get("Authorization") == "" {
+			t.Error("auth header missing")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer userSrv.Close()
+
+	gw, err := NewGateway("http://x", userSrv.URL, "http://y", "http://z", string(pemKey), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{"user_id": 1})
+	signed, _ := token.SignedString(key)
+
+	r := gin.New()
+	r.GET("/users/me", gw.JWTMiddleware(), gw.UserHandler())
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/users/me", nil)
+	req.Header.Set("Authorization", "Bearer "+signed)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 got %d", resp.StatusCode)
+	}
+	if !hit {
+		t.Fatal("backend not hit")
+	}
+
+	// invalid token
+	req, _ = http.NewRequest("GET", srv.URL+"/users/me", nil)
+	req.Header.Set("Authorization", "Bearer invalid")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 got %d", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary
- implement API gateway service with worker pool and JWT verification
- add gateway configuration loader
- update environment variables table in README
- include Dockerfile and compose entry
- add unit tests for gateway handlers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_686fdb3a7354832a83e406aff1e91995