### PR TITLE
Add Python end-to-end test suite

### DIFF
--- a/Testing/README.md
+++ b/Testing/README.md
@@ -1,0 +1,24 @@
+# Testing Suite
+
+This directory contains end-to-end tests for the Matchmaker services.
+
+## Running
+
+1. Start the services (e.g. via `docker-compose up` at the repository root).
+2. Install Python dependencies and run the tests:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
+The tests read service endpoints from environment variables matching the
+defaults defined in `internal/config/config.go`:
+
+- `GATEWAY_URL` (default `http://localhost:8080`)
+- `AUTH_SERVICE_URL` (default `http://localhost:8081`)
+- `CHAT_SERVICE_URL` (default `http://localhost:8082`)
+- `MATCH_SERVICE_URL` (default `http://localhost:8083`)
+- `USER_SERVICE_URL` (default `http://localhost:8084`)
+- `REPORT_SERVICE_URL` (default `http://localhost:8085`)
+- `JWT_PRIVATE_KEY` – RSA key used when exercising the gateway

--- a/Testing/requirements.txt
+++ b/Testing/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+requests
+websocket-client

--- a/Testing/test_services.py
+++ b/Testing/test_services.py
@@ -1,0 +1,156 @@
+import os
+import json
+import base64
+import requests
+import subprocess
+import tempfile
+import websocket
+import pytest
+
+GATEWAY_URL = os.getenv("GATEWAY_URL", "http://localhost:8080")
+AUTH_URL = os.getenv("AUTH_SERVICE_URL", "http://localhost:8081")
+CHAT_URL = os.getenv("CHAT_SERVICE_URL", "http://localhost:8082")
+MATCH_URL = os.getenv("MATCH_SERVICE_URL", "http://localhost:8083")
+USER_URL = os.getenv("USER_SERVICE_URL", "http://localhost:8084")
+REPORT_URL = os.getenv("REPORT_SERVICE_URL", "http://localhost:8085")
+
+
+def _b64(data: bytes) -> bytes:
+    return base64.urlsafe_b64encode(data).rstrip(b"=")
+
+
+def dummy_token(user_id: int = 1) -> str:
+    header = _b64(json.dumps({"alg": "none", "typ": "JWT"}).encode())
+    payload = _b64(json.dumps({"user_id": user_id}).encode())
+    return (header + b"." + payload + b".").decode()
+
+
+def signed_token(private_key: str, user_id: int = 1) -> str:
+    header = _b64(json.dumps({"alg": "RS256", "typ": "JWT"}).encode())
+    payload = _b64(json.dumps({"user_id": user_id}).encode())
+    message = header + b"." + payload
+    with tempfile.NamedTemporaryFile("wb", delete=False) as f:
+        f.write(private_key.encode())
+        path = f.name
+    try:
+        proc = subprocess.run(
+            ["openssl", "dgst", "-sha256", "-sign", path],
+            input=message,
+            stdout=subprocess.PIPE,
+            check=True,
+        )
+    finally:
+        os.unlink(path)
+    signature = _b64(proc.stdout)
+    return (message + b"." + signature).decode()
+
+
+def ws_url(base: str, path: str) -> str:
+    return base.replace("http", "ws", 1) + path
+
+
+@pytest.mark.parametrize(
+    "base",
+    [GATEWAY_URL, AUTH_URL, CHAT_URL, MATCH_URL, USER_URL, REPORT_URL],
+)
+def test_ping(base):
+    r = requests.get(base + "/ping")
+    assert r.status_code == 200
+    assert r.json() == {"message": "pong"}
+
+
+def test_user_service():
+    payload = {"email": "pytest@example.com", "name": "Tester"}
+    r = requests.post(USER_URL + "/internal/v1/users", json=payload)
+    assert r.status_code in (200, 201)
+    assert "id" in r.json()
+
+    r = requests.post(USER_URL + "/internal/v1/users", json={"name": "bad"})
+    assert r.status_code == 400
+
+
+def test_report_service():
+    good = {"dob": "2000-01-01", "tob": "12:00:00", "lat": 1, "lon": 2}
+    r = requests.post(REPORT_URL + "/internal/v1/reports", json=good)
+    assert r.status_code == 200
+
+    bad = {"dob": "nope"}
+    r = requests.post(REPORT_URL + "/internal/v1/reports", json=bad)
+    assert r.status_code == 400
+
+
+def test_match_service():
+    payload = {
+        "personA": {"dob": "2000-01-01", "tob": "12:00:00", "lat": 1, "lon": 2},
+        "personB": {"dob": "2001-01-01", "tob": "11:00:00", "lat": 1, "lon": 2},
+    }
+    r = requests.post(MATCH_URL + "/api/v1/analysis", json=payload)
+    assert r.status_code == 200
+    assert "score" in r.json()
+
+    r = requests.post(MATCH_URL + "/api/v1/analysis", json={"foo": "bar"})
+    assert r.status_code == 400
+
+
+def test_chat_service():
+    token = dummy_token()
+    ws = websocket.create_connection(
+        ws_url(CHAT_URL, "/api/v1/chat"),
+        header={"Authorization": f"Bearer {token}"},
+    )
+    ws.send("hello")
+    msg = ws.recv()
+    assert msg
+    ws.close()
+
+
+def test_chat_service_llm_failure():
+    token = dummy_token()
+    ws = websocket.create_connection(
+        ws_url(CHAT_URL, "/api/v1/chat"),
+        header={"Authorization": f"Bearer {token}"},
+    )
+    ws.send("trigger-error")
+    with pytest.raises(Exception):
+        ws.recv()
+    ws.close()
+
+
+def test_gateway_proxy():
+    key = os.getenv("JWT_PRIVATE_KEY")
+    if not key:
+        pytest.skip("JWT_PRIVATE_KEY not configured")
+    token = signed_token(key, 1)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    r = requests.get(GATEWAY_URL + "/api/v1/users/me", headers=headers)
+    assert r.status_code in (200, 404)
+
+    payload = {
+        "personA": {"dob": "2000-01-01", "tob": "12:00:00", "lat": 1, "lon": 2},
+        "personB": {"dob": "2001-01-01", "tob": "11:00:00", "lat": 1, "lon": 2},
+    }
+    r = requests.post(GATEWAY_URL + "/api/v1/analysis", json=payload, headers=headers)
+    assert r.status_code in (200, 400)
+
+    ws = websocket.create_connection(
+        ws_url(GATEWAY_URL, "/api/v1/chat"),
+        header={"Authorization": f"Bearer {token}"},
+    )
+    ws.send("hi")
+    ws.recv()
+    ws.close()
+
+
+def test_gateway_invalid_token():
+    headers = {"Authorization": "Bearer invalid"}
+    r = requests.get(GATEWAY_URL + "/api/v1/users/me", headers=headers)
+    assert r.status_code == 401
+
+    r = requests.post(GATEWAY_URL + "/api/v1/analysis", json={}, headers=headers)
+    assert r.status_code == 401
+
+    with pytest.raises(websocket.WebSocketBadStatusException):
+        websocket.create_connection(ws_url(GATEWAY_URL, "/api/v1/chat"), header=headers)
+
+


### PR DESCRIPTION
## Summary
- add `Testing` directory with pytest suite for all services
- provide default service URLs via environment variables
- document how to run tests
- list required Python packages

## Testing
- `pip install -r Testing/requirements.txt`
- `pytest -q Testing/test_services.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_687009f4e164832a8f022e23bfec38d3